### PR TITLE
feat: Dockerize Python ingestion application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,8 @@ ehthumbs.db
 backend/.env
 cubejs/.env
 frontend/.env.local
+
+# Backend specific
+backend/.DS_Store
+backend/*/__pycache__/
+backend/__pycache__/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10-slim-buster
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install poetry
+RUN pip install poetry
+
+# Copy the dependency files
+COPY pyproject.toml poetry.lock* /app/
+
+# Install project dependencies
+# --no-dev: Do not install development dependencies
+# --no-root: Do not install the project itself, only dependencies
+RUN poetry install --no-dev --no-root
+
+# Copy the rest of the application code
+COPY ./src /app/src
+COPY ./main.py /app/main.py
+
+# Command to run the application
+CMD ["python", "main.py"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,50 @@
-# Backend
+# Backend Ingestion Service
 
-This directory contains the backend code for the application.
+This directory contains the Python application responsible for ingesting data from the Spotify API and storing it in the PostgreSQL database.
+
+## Dockerization
+
+The application is containerized using Docker.
+
+### Build the Docker Image
+
+To build the Docker image locally, navigate to the `backend` directory and run:
+
+```bash
+docker build -t spotify-ingestion-backend .
+```
+
+### Run the Docker Container
+
+To run the Docker container locally, you need to provide the necessary environment variables. These include:
+
+*   `SPOTIFY_CLIENT_ID`: Your Spotify application client ID.
+*   `SPOTIFY_CLIENT_SECRET`: Your Spotify application client secret.
+*   `SPOTIFY_REFRESH_TOKEN`: Your Spotify refresh token.
+*   `DATABASE_URL`: The connection string for your PostgreSQL database (e.g., `postgresql://user:password@host:port/database`).
+
+You can run the container using the following command, replacing the placeholder values with your actual credentials:
+
+```bash
+docker run \
+  -e SPOTIFY_CLIENT_ID="YOUR_SPOTIFY_CLIENT_ID" \
+  -e SPOTIFY_CLIENT_SECRET="YOUR_SPOTIFY_CLIENT_SECRET" \
+  -e SPOTIFY_REFRESH_TOKEN="YOUR_SPOTIFY_REFRESH_TOKEN" \
+  -e DATABASE_URL="YOUR_DATABASE_URL" \
+  spotify-ingestion-backend
+```
+
+Alternatively, you can use a `.env` file (make sure it's in the `backend` directory when running the `docker run` command if you choose to mount it, though the Dockerfile itself doesn't copy it) and pass it to Docker:
+
+```bash
+# Create a .env file in the backend directory with your environment variables:
+# SPOTIFY_CLIENT_ID=YOUR_SPOTIFY_CLIENT_ID
+# SPOTIFY_CLIENT_SECRET=YOUR_SPOTIFY_CLIENT_SECRET
+# SPOTIFY_REFRESH_TOKEN=YOUR_SPOTIFY_REFRESH_TOKEN
+# DATABASE_URL=YOUR_DATABASE_URL
+
+docker run --env-file .env spotify-ingestion-backend
+```
+Note: The current Dockerfile does not copy the `.env` file into the image. The `--env-file` flag for `docker run` reads the file from your local machine where you execute the command.
+The application itself (main.py) is configured to load environment variables from a `.env` file if present when run locally (not in Docker), or directly from the environment when deployed (e.g., in Cloud Run or when passed via `docker run -e`).
+```


### PR DESCRIPTION
This commit introduces Docker support for the backend Python ingestion application.

Key changes:
- Added a `Dockerfile` to the `backend` directory to build the application image.
- Created a `backend/README.md` with instructions on how to build and run the Docker image, including environment variable setup.
- Updated the root `.gitignore` to exclude backend-specific files like `.DS_Store` and `__pycache__` directories.

This fulfills the requirements of Module 2.6 to Dockerize the Python Ingestion Application.