### PR TITLE
Refactor: Use real Spotify modules and fix runtime issues

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,69 +1,24 @@
 # At the top of main.py
-from src.logging_config import setup_logging
+from .src.logging_config import setup_logging
 setup_logging() # Call this early
 
 import logging # Keep this for using logging.getLogger() later
 import os
 import datetime
 from sqlalchemy.orm import Session
-from src.database import (
+from .src.database import (
     get_db_engine, init_db, get_session, get_max_played_at,
     upsert_artist, upsert_album, upsert_track, insert_listen,
     upsert_podcast_series, upsert_podcast_episode
 )
-from src.models import Artist, Album, Track, Listen, PodcastSeries, PodcastEpisode
-from src.normalizer import SpotifyItemNormalizer
-from src.exceptions import DatabaseError, ConfigurationError, SpotifyAuthError, SpotifyAPIError # Updated import
+from .src.models import Artist, Album, Track, Listen, PodcastSeries, PodcastEpisode
+from .src.normalizer import SpotifyItemNormalizer
+from .src.exceptions import DatabaseError, ConfigurationError, SpotifyAuthError, SpotifyAPIError # Updated import
 # For this subtask, we'll use the placeholder functions in main.py for Spotify operations,
 # so ConfigurationError for Spotify credentials won't be hit from config.py yet.
-# from backend.src.config import get_spotify_credentials # Would be ideal
-# from backend.src.spotify_client import SpotifyOAuthClient # Would be ideal
-# from backend.src.spotify_data import get_recently_played_tracks # Would be ideal
-
-# Placeholder get_spotify_credentials - real one would be in config.py
-def get_spotify_credentials(): # In a real scenario, this would be `from backend.src.config import get_spotify_credentials`
-    # This placeholder won't raise ConfigurationError itself.
-    # If SPOTIFY_CLIENT_ID etc. were read here using os.getenv directly and were missing,
-    # it would be the place for ConfigurationError.
-    # For now, we rely on the database URL check in config.py to test ConfigurationError handling.
-    logging.warning("Using placeholder get_spotify_credentials() in main.py")
-    return "dummy_client_id", "dummy_client_secret", "dummy_refresh_token" # These would trigger ConfigurationError if get_env_variable was used here directly
-
-# Placeholder SpotifyOAuthClient - real one in spotify_client.py
-class SpotifyOAuthClient: # In a real scenario, this would be `from backend.src.spotify_client import SpotifyOAuthClient`
-    def __init__(self, client_id, client_secret, refresh_token):
-        logging.warning(f"Using placeholder SpotifyOAuthClient in main.py with {client_id[:5]}...")
-        # Real client might raise SpotifyAuthError on init if refresh token is invalid immediately
-        self.access_token = "DUMMY_ACCESS_TOKEN_FOR_SUBTASK_MAIN_PY" # Placeholder token
-
-    def get_access_token_from_refresh(self):
-        # Real method in spotify_client.py raises SpotifyAuthError
-        logging.warning("Using placeholder get_access_token_from_refresh() in main.py")
-        # Simulate an auth error for testing if needed:
-        # raise SpotifyAuthError("Simulated auth error from placeholder client")
-        return self.access_token
-
-# Placeholder get_recently_played_tracks - real one in spotify_data.py
-def get_recently_played_tracks(access_token, limit=50, after=None): # In a real scenario, this would be `from backend.src.spotify_data import get_recently_played_tracks`
-    logging.warning(f"Using placeholder get_recently_played_tracks() in main.py with token {access_token[:5]}..., limit {limit}, after {after}")
-    # Real function might raise SpotifyAPIError or SpotifyAuthError (if token expired mid-request)
-    # Simulate an API error for testing if needed:
-    # raise SpotifyAPIError("Simulated API error from placeholder tracks fetch")
-    return {
-        "items": [
-            {
-                "track": {
-                    "id": "track_id_1", "name": "Test Track 1", "type": "track",
-                    "artists": [{"id": "artist_id_1", "name": "Test Artist 1", "external_urls": {"spotify":"artist_url_1"}}],
-                    "album": {"id": "album_id_1", "name": "Test Album 1", "images": [{"url": "img_url_1"}], "external_urls": {"spotify":"album_url_1"}, "release_date":"2023-01-01", "release_date_precision":"day"},
-                }, "played_at": "2023-01-15T10:30:00Z"
-            },
-            {
-                "track": {"id": "episode_id_1", "name": "Test Episode 1", "type": "episode"},
-                "played_at": "2023-01-15T11:00:00Z"
-            }
-        ], "next": None
-    }
+from backend.src.config import get_spotify_credentials
+from backend.src.spotify_client import SpotifyOAuthClient
+from backend.src.spotify_data import get_recently_played_tracks
 
 # Remove: logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s')
 logger = logging.getLogger(__name__) # Standard way to get logger per module

--- a/backend/tests/test_ingestion_logic.py
+++ b/backend/tests/test_ingestion_logic.py
@@ -10,17 +10,17 @@ from sqlalchemy import create_engine, text, JSON, TEXT
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 
-from src.models import Base, Artist, Album, Track, Listen, RecentlyPlayedTracksRaw, PodcastSeries, PodcastEpisode
+from backend.src.models import Base, Artist, Album, Track, Listen, RecentlyPlayedTracksRaw, PodcastSeries, PodcastEpisode
 # Import for mocking normalizer
-from src.normalizer import SpotifyItemNormalizer as RealNormalizer
+from backend.src.normalizer import SpotifyItemNormalizer as RealNormalizer
 
-from src.database import (
+from backend.src.database import (
     get_max_played_at as real_get_max_played_at,
     upsert_artist, upsert_album, upsert_track,
     insert_listen as real_insert_listen,
     init_db
 )
-from main import process_spotify_data
+from backend.main import process_spotify_data
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -136,16 +136,16 @@ class TestIngestionLogic(unittest.TestCase):
 
         self.assertEqual(actual_played_at_from_db, expected_played_at_dt)
 
-    @patch('main.get_spotify_credentials')
-    @patch('main.SpotifyOAuthClient')
-    @patch('main.get_recently_played_tracks')
-    @patch('main.get_session')
-    @patch('main.get_max_played_at')
-    @patch('main.SpotifyItemNormalizer')
-    @patch('main.insert_listen')
-    @patch('main.upsert_artist')
-    @patch('main.upsert_album')
-    @patch('main.upsert_track')
+    @patch('backend.main.get_spotify_credentials')
+    @patch('backend.main.SpotifyOAuthClient')
+    @patch('backend.main.get_recently_played_tracks')
+    @patch('backend.main.get_session')
+    @patch('backend.main.get_max_played_at')
+    @patch('backend.main.SpotifyItemNormalizer')
+    @patch('backend.main.insert_listen')
+    @patch('backend.main.upsert_artist')
+    @patch('backend.main.upsert_album')
+    @patch('backend.main.upsert_track')
     @patch.dict(os.environ, {"DATABASE_URL": TEST_SQLALCHEMY_DATABASE_URL, "LOG_LEVEL": "DEBUG"}) # Added to provide DATABASE_URL
     def test_process_spotify_data_flow_logic(
         self, mock_upsert_track, mock_upsert_album, mock_upsert_artist,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -200,7 +200,9 @@ def test_main_handles_spotify_api_error(
 
 @patch('backend.main.logger.error') # Changed from logging.error to logger.error
 @patch('backend.main.get_db_engine', side_effect=Exception("Simulated DB Connection Error"))
-def test_main_handles_db_engine_error(mock_get_db_engine_fails, mock_logger_error): # Renamed mock_logging_error
+@patch('backend.main.get_spotify_credentials') # Added this mock
+def test_main_handles_db_engine_error(mock_get_spotify_credentials, mock_get_db_engine_fails, mock_logger_error): # Renamed mock_logging_error and added new mock
+    mock_get_spotify_credentials.return_value = ("test_id", "test_secret", "test_refresh") # Mock successful credential retrieval
     from backend.main import process_spotify_data
 
     process_spotify_data() # No try-except block here in the test

--- a/backend/tests/test_podcast_ingestion.py
+++ b/backend/tests/test_podcast_ingestion.py
@@ -7,16 +7,16 @@ from sqlalchemy import create_engine, text, JSON # Added JSON
 from sqlalchemy.orm import sessionmaker
 
 # Models and db functions
-from src.models import Base, Artist, Album, Track, Listen, PodcastSeries, PodcastEpisode, RecentlyPlayedTracksRaw # Added RecentlyPlayedTracksRaw
-from src.database import (
+from backend.src.models import Base, Artist, Album, Track, Listen, PodcastSeries, PodcastEpisode, RecentlyPlayedTracksRaw # Added RecentlyPlayedTracksRaw
+from backend.src.database import (
     get_max_played_at, upsert_artist, upsert_album, upsert_track,
     upsert_podcast_series, upsert_podcast_episode, insert_listen
 ) # Removed init_db as it's not used directly in tests after setup
 # Main processing function
-from main import process_spotify_data # Removed get_spotify_credentials, SpotifyOAuthClient as they are mocked
+from backend.main import process_spotify_data # Removed get_spotify_credentials, SpotifyOAuthClient as they are mocked
 
 # Normalizer
-from src.normalizer import SpotifyItemNormalizer
+from backend.src.normalizer import SpotifyItemNormalizer
 
 
 # Helper to create a timezone-aware datetime object
@@ -159,11 +159,11 @@ class TestPodcastIngestion(unittest.TestCase):
         self.session.rollback()
         self.session.close()
 
-    @patch('main.get_spotify_credentials')
-    @patch('main.SpotifyOAuthClient')
-    @patch('main.get_recently_played_tracks')
+    @patch('backend.main.get_spotify_credentials')
+    @patch('backend.main.SpotifyOAuthClient')
+    @patch('backend.main.get_recently_played_tracks')
     # Patch get_db_engine within main.py to return our in-memory SQLite engine
-    @patch('main.get_db_engine')
+    @patch('backend.main.get_db_engine')
     def test_ingestion_mixed_new_and_existing_items(
         self, mock_get_main_db_engine, mock_get_recently_played,
         mock_spotify_oauth_client, mock_get_creds
@@ -255,10 +255,10 @@ class TestPodcastIngestion(unittest.TestCase):
         self.assertEqual(self.session.query(PodcastEpisode).count(), 2)
 
 
-    @patch('main.get_spotify_credentials')
-    @patch('main.SpotifyOAuthClient')
-    @patch('main.get_recently_played_tracks')
-    @patch('main.get_db_engine')
+    @patch('backend.main.get_spotify_credentials')
+    @patch('backend.main.SpotifyOAuthClient')
+    @patch('backend.main.get_recently_played_tracks')
+    @patch('backend.main.get_db_engine')
     def test_ingestion_only_existing_items_returned(
         self, mock_get_main_db_engine, mock_get_recently_played,
         mock_spotify_oauth_client, mock_get_creds


### PR DESCRIPTION
I replaced placeholder functions in backend/main.py with actual implementations from the backend.src package for:
- Spotify credential fetching (config.py)
- SpotifyOAuthClient (spotify_client.py)
- Recently played tracks fetching (spotify_data.py)

This change restores the intended data processing flow.

Additionally, I resolved the following issues identified during testing:
- Installed missing Python dependencies (python-json-logger, SQLAlchemy, python-dotenv, tenacity, requests-mock).
- Corrected Python import paths by setting PYTHONPATH and using relative imports within the 'backend' module.
- Updated import statements and mock targets in your test suite (backend/tests/*) to align with the new module structure.
- Ensured all 89 tests pass after these changes.