### PR TITLE
Add descriptions to cube members

### DIFF
--- a/cubejs/schema/Album.js
+++ b/cubejs/schema/Album.js
@@ -6,27 +6,33 @@ cube(`Albums`, {
       sql: `album_id`,
       type: `string`,
       primaryKey: true,
-      shown: true
+      shown: true,
+      description: "The unique identifier for the album."
     },
     name: {
       sql: `name`,
-      type: `string`
+      type: `string`,
+      description: "The name of the album."
     },
     releaseDate: {
       sql: `release_date`,
-      type: `time`
+      type: `time`,
+      description: "The release date of the album."
     },
     albumType: {
       sql: `album_type`,
-      type: `string`
+      type: `string`,
+      description: "The type of the album (e.g., album, single)."
     },
     spotifyUrl: {
       sql: `spotify_url`,
-      type: `string`
+      type: `string`,
+      description: "The Spotify URL of the album."
     },
     imageUrl: {
       sql: `image_url`,
-      type: `string`
+      type: `string`,
+      description: "The URL of the album's cover art."
     }
   },
 
@@ -39,7 +45,8 @@ cube(`Albums`, {
 
   measures: {
     count: {
-      type: `count`
+      type: `count`,
+      description: "The total number of albums."
     }
   }
 });

--- a/cubejs/schema/Artist.js
+++ b/cubejs/schema/Artist.js
@@ -6,29 +6,35 @@ cube(`Artists`, {
       sql: `artist_id`,
       type: `string`,
       primaryKey: true,
-      shown: true
+      shown: true,
+      description: "The unique identifier for the artist."
     },
     name: {
       sql: `name`,
-      type: `string`
+      type: `string`,
+      description: "The name of the artist."
     },
     spotifyUrl: {
       sql: `spotify_url`,
-      type: `string`
+      type: `string`,
+      description: "The Spotify URL of the artist."
     },
     imageUrl: {
       sql: `image_url`,
-      type: `string`
+      type: `string`,
+      description: "The URL of the artist's image."
     },
     genres: {
       sql: `genres`,
-      type: `string` // Cube.js will handle array type appropriately
+      type: `string`, // Cube.js will handle array type appropriately
+      description: "The genres associated with the artist."
     }
   },
 
   measures: {
     count: {
-      type: `count`
+      type: `count`,
+      description: "The total number of artists."
     }
   }
 });

--- a/cubejs/schema/Listen.js
+++ b/cubejs/schema/Listen.js
@@ -6,15 +6,18 @@ cube(`Listens`, {
       sql: `listen_id`,
       type: `number`,
       primaryKey: true,
-      shown: true
+      shown: true,
+      description: "The unique identifier for the listen event."
     },
     playedAt: {
       sql: `played_at`,
-      type: `time`
+      type: `time`,
+      description: "The timestamp when the listen event occurred."
     },
     itemType: {
       sql: `item_type`,
-      type: `string`
+      type: `string`,
+      description: "The type of item listened to (e.g., track, podcast episode)."
     }
   },
 
@@ -37,7 +40,8 @@ cube(`Listens`, {
 
   measures: {
     count: {
-      type: `count`
+      type: `count`,
+      description: "The total number of listen events."
     },
     totalDurationSeconds: { // Renamed from totalDurationMs
       // This sums the duration in seconds from the Tracks table.
@@ -45,7 +49,8 @@ cube(`Listens`, {
       sql: `${Tracks}.durationSeconds`, // References the updated dimension in Tracks
       type: `sum`,
       format: `decimal(2)`, // Format to two decimal places
-      title: `Total Listen Duration (s)`
+      title: `Total Listen Duration (s)`,
+      description: "The total duration of all listen events in seconds."
     }
   },
 

--- a/cubejs/schema/Track.js
+++ b/cubejs/schema/Track.js
@@ -6,39 +6,48 @@ cube(`Tracks`, {
       sql: `track_id`,
       type: `string`,
       primaryKey: true,
-      shown: true
+      shown: true,
+      description: "The unique identifier for the track."
     },
     name: {
       sql: `name`,
-      type: `string`
+      type: `string`,
+      description: "The name of the track."
     },
     durationSeconds: { // Renamed from durationMs
       sql: `duration_ms / 1000.0`, // Convert to seconds
-      type: `number`
+      type: `number`,
+      description: "The duration of the track in seconds."
     },
     explicit: {
       sql: `explicit`,
-      type: `boolean`
+      type: `boolean`,
+      description: "Indicates if the track has explicit content."
     },
     popularity: {
       sql: `popularity`,
-      type: `number`
+      type: `number`,
+      description: "The popularity of the track (0-100)."
     },
     previewUrl: {
       sql: `preview_url`,
-      type: `string`
+      type: `string`,
+      description: "The URL of the track's preview."
     },
     spotifyUrl: {
       sql: `spotify_url`,
-      type: `string`
+      type: `string`,
+      description: "The Spotify URL of the track."
     },
     availableMarkets: {
       sql: `available_markets`,
-      type: `string` // Cube.js will handle array type appropriately
+      type: `string`, // Cube.js will handle array type appropriately
+      description: "A list of markets where the track is available."
     },
     lastPlayedAt: {
       sql: `last_played_at`,
-      type: `time`
+      type: `time`,
+      description: "The timestamp when the track was last played."
     }
   },
 
@@ -51,12 +60,14 @@ cube(`Tracks`, {
 
   measures: {
     count: {
-      type: `count`
+      type: `count`,
+      description: "The total number of tracks."
     },
     totalDurationSeconds: { // Renamed from totalDuration
       sql: `duration_ms / 1000.0`, // Use the original ms value for sum then implicitly it's in seconds
       type: `sum`,
-      format: `decimal(2)` // Format to two decimal places
+      format: `decimal(2)`, // Format to two decimal places
+      description: "The total duration of all tracks in seconds."
     }
   }
 });


### PR DESCRIPTION
This change adds a `description` field to all dimensions and measures in the following Cube.js schema files:
- `cubejs/schema/Album.js`
- `cubejs/schema/Artist.js`
- `cubejs/schema/Listen.js`
- `cubejs/schema/Track.js`

These descriptions will provide more context and clarity for you when using the data analytics platform.